### PR TITLE
Sox: remove stray `dither`

### DIFF
--- a/muxtools/audio/extractors.py
+++ b/muxtools/audio/extractors.py
@@ -315,7 +315,7 @@ class Sox(Trimmer):
             input = AudioFile.from_file(input, self)
         out = make_output(input.file, "flac", f"trimmed", self.output)
         self.trim = sanitize_trims(self.trim, self.num_frames, not self.trim_use_ms, allow_negative_start=True, caller=self)
-        source = ensure_valid_in(input, dither=False, caller=self, supports_pipe=False)
+        source = ensure_valid_in(input, caller=self, supports_pipe=False)
 
         if len(self.trim) > 1:
             files_to_concat = []


### PR DESCRIPTION
`dither` was removed in 99d7455.

Fixes:

```
    audio_en = do_audio(USABD, track=0, encoder=FLAC(), trims=(-38, None))
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "Lib\site-packages\vsmuxtools\extension\audio.py", line 105, in do_audio
    return mt_audio(fileIn, track, trims, fps, num_frames, extractor, trimmer, encoder, quiet, output)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "Lib\site-packages\muxtools\functions.py", line 79, in do_audio
    trimmed = trimmer.trim_audio(audio, quiet)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "Lib\site-packages\muxtools\audio\extractors.py", line 318, in trim_audio
    source = ensure_valid_in(input, dither=False, caller=self, supports_pipe=False)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
TypeError: ensure_valid_in() got an unexpected keyword argument 'dither'

```